### PR TITLE
More page tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
+    "axios": "^1.11.0",
     "tsx": "^4.20.4",
     "typescript": "^5.9.2",
     "wikijs": "^6.4.1",

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,8 @@ import { z } from 'zod';
 import { findMatchesForTopic } from './tools/wiki/findMatchesForTopic';
 import { getSummaryForPage } from './tools/wiki/getSummaryForPage';
 import { getRawContentForPage } from './tools/wiki/getRawContentForPage';
+import { getBacklinksForPage } from './tools/wiki/getBacklinksForPage';
+import { getCategoriesForContent } from './tools/wiki/getCategoriesForPage';
 
 const server = new McpServer({
 	name: 'osrs-mcp',
@@ -20,7 +22,7 @@ server.tool(
 	'search_osrs_wiki_for_topic',
 	'Use whenever the user asks about an Old School RuneScape topic, or if the agent needs to gain further context on a topic to improve a response. Always defer to using the information from the wiki instead of potentially-outdated training data.',
 	{
-		topic: z.string().describe('The specific Old School RuneScape topic to ask the wiki about.'),
+		topic: z.string().describe('The specific Old School RuneScape topic to search the Wiki for.'),
 	},
 	async ({ topic }) => findMatchesForTopic(topic),
 );
@@ -29,18 +31,45 @@ server.tool(
 	'get_osrs_wiki_page_summary',
 	'Use this to get the summary for the page name in the OSRS Wiki. This is intended to be used after getting a page title from the ask_wiki_about_topic tool, which ensures this tool is only used for pages that are known to exist.',
 	{
-		pageName: z.string().describe('The name of the page to get the summary for; this is the "title" value for results in the ask_wiki_about_topic tool.'),
+		pageName: z.string().describe('The name of the page to get the summary for.'),
 	},
 	async ({ pageName }) => getSummaryForPage(pageName),
 )
 
 server.tool(
 	'get_osrs_wiki_page_full_content',
-	'Use this to get the full Wiki Text for the page name in the OSRS Wiki. This is intended to be used after getting a page title from the ask_wiki_about_topic tool, which ensures this tool is only used for pages that are known to exist.',
+	'Use this to get the full Wiki Text for the page name in the OSRS Wiki. Use this when the get_osrs_wiki_page_summary tool does not provide a detailed enough explanation of the given page name.',
 	{
-		pageName: z.string().describe('The name of the page to get the summary for; this is the "title" value for results in the ask_wiki_about_topic tool.'),
+		pageName: z.string().describe('The name of the page to get the full content for.'),
 	},
 	async ({ pageName }) => getRawContentForPage(pageName),
+)
+
+server.tool(
+	'get_osrs_wiki_page_backlinks',
+	'Use this to get the backlinks for the given page name in the OSRS Wiki.',
+	{
+		pageName: z.string().describe('The name of the page to get the backlinks for.'),
+	},
+	async ({ pageName }) => getBacklinksForPage(pageName),
+)
+
+server.tool(
+	'get_osrs_wiki_page_categories',
+	'Use this to get the categories for the given page name in the OSRS Wiki.',
+	{
+		pageName: z.string().describe('The name of the page to get the categories for.'),
+	},
+	async ({ pageName }) => getCategoriesForContent(pageName),
+)
+
+server.tool(
+	'get_osrs_wiki_page_tables',
+	'Use this to get the tables for the given page name in the OSRS Wiki.',
+	{
+		pageName: z.string().describe('The name of the page to get the tables for.'),
+	},
+	async ({ pageName }) => getCategoriesForContent(pageName),
 )
 
 async function main() {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,7 +5,9 @@ import { findMatchesForTopic } from './tools/wiki/findMatchesForTopic';
 import { getSummaryForPage } from './tools/wiki/getSummaryForPage';
 import { getRawContentForPage } from './tools/wiki/getRawContentForPage';
 import { getBacklinksForPage } from './tools/wiki/getBacklinksForPage';
-import { getCategoriesForContent } from './tools/wiki/getCategoriesForPage';
+import { getCategoriesForPage } from './tools/wiki/getCategoriesForPage';
+import { getMainImageForPage } from './tools/wiki/getMainImageForPage';
+import { getImagesForPage } from './tools/wiki/getImagesForPage';
 
 const server = new McpServer({
 	name: 'osrs-mcp',
@@ -60,7 +62,7 @@ server.tool(
 	{
 		pageName: z.string().describe('The name of the page to get the categories for.'),
 	},
-	async ({ pageName }) => getCategoriesForContent(pageName),
+	async ({ pageName }) => getCategoriesForPage(pageName),
 )
 
 server.tool(
@@ -69,7 +71,25 @@ server.tool(
 	{
 		pageName: z.string().describe('The name of the page to get the tables for.'),
 	},
-	async ({ pageName }) => getCategoriesForContent(pageName),
+	async ({ pageName }) => getCategoriesForPage(pageName),
+)
+
+server.tool(
+	'get_osrs_wiki_page_images',
+	'Use this to get the images for the given page name in the OSRS Wiki.',
+	{
+		pageName: z.string().describe('The name of the page to get the images for.'),
+	},
+	async ({ pageName }) => getImagesForPage(pageName),
+)
+
+server.tool(
+	'get_osrs_wiki_page_main_image',
+	'Use this to get the main image for the given page name in the OSRS Wiki.',
+	{
+		pageName: z.string().describe('The name of the page to get the main image for.'),
+	},
+	async ({ pageName }) => getMainImageForPage(pageName),
 )
 
 async function main() {

--- a/src/tools/wiki/getBacklinksForPage.ts
+++ b/src/tools/wiki/getBacklinksForPage.ts
@@ -1,0 +1,26 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { getPageForTopic } from '../../utils/osrsWiki.js';
+
+export async function getBacklinksForPage(
+	/**
+	 * The page to fetch the backlinks for
+	 */
+	pageName: string,
+): Promise<CallToolResult> {
+	if (!pageName || pageName.trim() === '') {
+		throw new Error('pageName cannot be empty');
+	}
+
+	const response = await getPageForTopic(pageName)
+	const backlinks = await response.backlinks()
+
+	return {
+		content: [
+			{
+				type: 'text',
+				text: JSON.stringify(backlinks, null, 2),
+			},
+		],
+	};
+}

--- a/src/tools/wiki/getCategoriesForPage.ts
+++ b/src/tools/wiki/getCategoriesForPage.ts
@@ -1,0 +1,27 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { getPageForTopic } from '../../utils/osrsWiki.js';
+
+export async function getCategoriesForContent(
+	/**
+	 * The page to fetch the categories for
+	 */
+	pageName: string,
+): Promise<CallToolResult> {
+	if (!pageName || pageName.trim() === '') {
+		throw new Error('pageName cannot be empty');
+	}
+
+	const response = await getPageForTopic(pageName)
+	const categories = await response.categories()
+
+
+	return {
+		content: [
+			{
+				type: 'text',
+				text: JSON.stringify(categories, null, 2),
+			},
+		],
+	};
+}

--- a/src/tools/wiki/getImagesForPage.ts
+++ b/src/tools/wiki/getImagesForPage.ts
@@ -2,9 +2,9 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import { getPageForTopic } from '../../utils/osrsWiki.js';
 
-export async function getCategoriesForPage(
+export async function getImagesForPage(
 	/**
-	 * The page to fetch the categories for
+	 * The page to fetch the tables for
 	 */
 	pageName: string,
 ): Promise<CallToolResult> {
@@ -13,14 +13,13 @@ export async function getCategoriesForPage(
 	}
 
 	const response = await getPageForTopic(pageName)
-	const categories = await response.categories()
-
+	const images = await response.images()
 
 	return {
 		content: [
 			{
 				type: 'text',
-				text: JSON.stringify(categories, null, 2),
+				text: JSON.stringify(images, null, 2),
 			},
 		],
 	};

--- a/src/tools/wiki/getMainImageForPage.ts
+++ b/src/tools/wiki/getMainImageForPage.ts
@@ -1,10 +1,11 @@
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import { getPageForTopic } from '../../utils/osrsWiki.js';
+import axios from 'axios';
 
-export async function getCategoriesForPage(
+export async function getMainImageForPage(
 	/**
-	 * The page to fetch the categories for
+	 * The page to fetch the tables for
 	 */
 	pageName: string,
 ): Promise<CallToolResult> {
@@ -13,14 +14,15 @@ export async function getCategoriesForPage(
 	}
 
 	const response = await getPageForTopic(pageName)
-	const categories = await response.categories()
-
+	const mainImageUrl = await response.mainImage()
+	const mainImageResponse = await axios.get(mainImageUrl, { responseType: 'arraybuffer' });
 
 	return {
 		content: [
 			{
-				type: 'text',
-				text: JSON.stringify(categories, null, 2),
+				type: 'image',
+				data: Buffer.from(mainImageResponse.data).toString('base64'),
+				mimeType: 'image/png',
 			},
 		],
 	};

--- a/src/tools/wiki/getTablesForPage.ts
+++ b/src/tools/wiki/getTablesForPage.ts
@@ -1,0 +1,27 @@
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+
+import { getPageForTopic } from '../../utils/osrsWiki.js';
+
+export async function getTablesForContent(
+	/**
+	 * The page to fetch the tables for
+	 */
+	pageName: string,
+): Promise<CallToolResult> {
+	if (!pageName || pageName.trim() === '') {
+		throw new Error('pageName cannot be empty');
+	}
+
+	const response = await getPageForTopic(pageName)
+	const tables = await response.tables()
+
+
+	return {
+		content: [
+			{
+				type: 'text',
+				text: JSON.stringify(tables, null, 2),
+			},
+		],
+	};
+}

--- a/src/tools/wiki/getTablesForPage.ts
+++ b/src/tools/wiki/getTablesForPage.ts
@@ -2,7 +2,7 @@ import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 
 import { getPageForTopic } from '../../utils/osrsWiki.js';
 
-export async function getTablesForContent(
+export async function getTablesForPage(
 	/**
 	 * The page to fetch the tables for
 	 */
@@ -14,7 +14,6 @@ export async function getTablesForContent(
 
 	const response = await getPageForTopic(pageName)
 	const tables = await response.tables()
-
 
 	return {
 		content: [


### PR DESCRIPTION
# Summary

<!-- A summary of the changes -->

Adds several new tools to query page data:
* `get_osrs_wiki_page_backlinks`
* `get_osrs_wiki_page_categories`
* `get_osrs_wiki_page_tables`
* `get_osrs_wiki_page_images` (PNG image array)
* `get_osrs_wiki_page_main_image` (PNG image)

## MCP Inspector QA

<!-- Instructions on how to test the changes in the MCP Inspector -->

The most-interesting new tools are the image tools, which will render the image in the inspector.

1. Run `yarn build-and-test`
2. Click "Connect"
3. Click the "Tools" tab > "List Tools" button
4. Select `get_osrs_wiki_page_main_image` > search for a page (I used "Green dragon")
5. Make sure you see the main PNG image of the topic you queried

